### PR TITLE
feat: add extension button popup for calendar quick add

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,6 +11,11 @@
     "128": "icons/icon128.png"
   },
 
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Googleカレンダーに追加"
+  },
+
   "background": {
     "service_worker": "js/background.js"
   },

--- a/public/popup.html
+++ b/public/popup.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Googleカレンダーに追加</title>
+  <style>
+    body {
+      width: 300px;
+      padding: 16px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 14px;
+      margin: 0;
+    }
+    
+    .header {
+      text-align: center;
+      margin-bottom: 16px;
+      font-weight: 600;
+      color: #1976d2;
+    }
+    
+    .input-group {
+      margin-bottom: 16px;
+    }
+    
+    label {
+      display: block;
+      margin-bottom: 4px;
+      font-weight: 500;
+      color: #333;
+    }
+    
+    textarea {
+      width: 100%;
+      padding: 8px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-size: 14px;
+      font-family: inherit;
+      resize: vertical;
+      min-height: 60px;
+      box-sizing: border-box;
+    }
+    
+    textarea:focus {
+      outline: none;
+      border-color: #1976d2;
+    }
+    
+    .button-group {
+      display: flex;
+      gap: 8px;
+    }
+    
+    button {
+      flex: 1;
+      padding: 10px 16px;
+      border: none;
+      border-radius: 4px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+    
+    .add-button {
+      background-color: #1976d2;
+      color: white;
+    }
+    
+    .add-button:hover {
+      background-color: #1565c0;
+    }
+    
+    .add-button:disabled {
+      background-color: #ccc;
+      cursor: not-allowed;
+    }
+    
+    .cancel-button {
+      background-color: #f5f5f5;
+      color: #666;
+    }
+    
+    .cancel-button:hover {
+      background-color: #e0e0e0;
+    }
+    
+    .status {
+      margin-top: 8px;
+      padding: 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      display: none;
+    }
+    
+    .status.success {
+      background-color: #e8f5e8;
+      color: #2e7d32;
+      border: 1px solid #c8e6c9;
+    }
+    
+    .status.error {
+      background-color: #ffebee;
+      color: #c62828;
+      border: 1px solid #ffcdd2;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    📅 Googleカレンダーに追加
+  </div>
+  
+  <div class="input-group">
+    <label for="eventText">イベント内容</label>
+    <textarea 
+      id="eventText" 
+      placeholder="例: 会議 明日の2時から3時まで"
+      rows="3"
+    ></textarea>
+  </div>
+  
+  <div class="button-group">
+    <button type="button" class="cancel-button" id="cancelButton">
+      キャンセル
+    </button>
+    <button type="button" class="add-button" id="addButton">
+      追加
+    </button>
+  </div>
+  
+  <div class="status" id="status"></div>
+  
+  <script src="js/popup.js"></script>
+</body>
+</html>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,0 +1,101 @@
+import { extractDateTime } from "./extract";
+import { createGoogleCalendarUrl } from "./google_calendar";
+
+const getCurrentTabInfo = async (): Promise<chrome.tabs.Tab[]> => {
+  return await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+}
+
+const getCurrentTabMessage = async (): Promise<string> => {
+  const tabs = await getCurrentTabInfo();
+  const currentTitle = tabs[0].title || "";
+  const currentUrl = tabs[0].url || "";
+  const currentTab = `${currentTitle}\n${currentUrl}`;
+  return currentTab;
+}
+
+const showStatus = (message: string, type: 'success' | 'error') => {
+  const statusElement = document.getElementById('status') as HTMLDivElement;
+  statusElement.textContent = message;
+  statusElement.className = `status ${type}`;
+  statusElement.style.display = 'block';
+  
+  // Hide status after 3 seconds
+  setTimeout(() => {
+    statusElement.style.display = 'none';
+  }, 3000);
+}
+
+const addToCalendar = async (eventText: string) => {
+  try {
+    if (!eventText.trim()) {
+      showStatus('イベント内容を入力してください', 'error');
+      return;
+    }
+
+    // Extract date/time from the input text
+    const { textWithoutDate, startDateTime, endDateTime } = extractDateTime(eventText);
+
+    // Get current tab information for details
+    const currentTab = await getCurrentTabMessage();
+
+    // Create Google Calendar URL
+    const calendarUrl = createGoogleCalendarUrl(textWithoutDate, currentTab, startDateTime, endDateTime);
+
+    // Open calendar in new tab
+    await chrome.tabs.create({ url: calendarUrl.href });
+
+    // Show success message
+    showStatus('カレンダーを開きました！', 'success');
+
+    // Close popup after a short delay
+    setTimeout(() => {
+      window.close();
+    }, 1000);
+
+  } catch (error) {
+    console.error('Error adding to calendar:', error);
+    showStatus('エラーが発生しました', 'error');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const eventTextArea = document.getElementById('eventText') as HTMLTextAreaElement;
+  const addButton = document.getElementById('addButton') as HTMLButtonElement;
+  const cancelButton = document.getElementById('cancelButton') as HTMLButtonElement;
+
+  // Focus on textarea when popup opens
+  eventTextArea.focus();
+
+  // Add button click handler
+  addButton.addEventListener('click', async () => {
+    const eventText = eventTextArea.value;
+    
+    // Disable button during processing
+    addButton.disabled = true;
+    addButton.textContent = '処理中...';
+    
+    await addToCalendar(eventText);
+    
+    // Re-enable button
+    addButton.disabled = false;
+    addButton.textContent = '追加';
+  });
+
+  // Cancel button click handler
+  cancelButton.addEventListener('click', () => {
+    window.close();
+  });
+
+  // Enter key handler (Ctrl+Enter to submit)
+  eventTextArea.addEventListener('keydown', (event) => {
+    if (event.ctrlKey && event.key === 'Enter') {
+      addButton.click();
+    }
+  });
+
+  // Auto-resize textarea
+  eventTextArea.addEventListener('input', () => {
+    eventTextArea.style.height = 'auto';
+    eventTextArea.style.height = eventTextArea.scrollHeight + 'px';
+  });
+});

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -5,6 +5,7 @@ const srcDir = path.join(__dirname, "..", "src");
 module.exports = {
     entry: {
       background: path.join(srcDir, 'background.ts'),
+      popup: path.join(srcDir, 'popup.ts'),
     },
     output: {
         path: path.join(__dirname, "../dist/js"),
@@ -14,7 +15,7 @@ module.exports = {
         splitChunks: {
             name: "vendor",
             chunks(chunk) {
-              return chunk.name !== 'background';
+              return chunk.name !== 'background' && chunk.name !== 'popup';
             }
         },
     },


### PR DESCRIPTION
## Summary
- Add popup action to manifest.json with Japanese interface
- Create popup.html with responsive UI and form validation
- Implement popup.ts integrating with existing calendar functions
- Update webpack configuration for popup build

## Fixes
Closes #1

## Test Plan
1. Build extension: `npm run build`
2. Load in Chrome developer mode
3. Click extension button to open popup
4. Enter event text and click "追加"
5. Verify Google Calendar opens with event

🤖 Generated with [Claude Code](https://claude.ai/code)